### PR TITLE
Added Amazon subclasses to allow the use of a single configuration file ...

### DIFF
--- a/Oara/Network/Publisher/Amazon.php
+++ b/Oara/Network/Publisher/Amazon.php
@@ -28,6 +28,11 @@
  *
  */
 class Oara_Network_Publisher_Amazon extends Oara_Network {
+        /**
+         * The network to use if none is specified
+         */
+        const NETWORK = 'us';
+        
 	/**
 	 * Export Merchants Parameters
 	 * @var array
@@ -70,6 +75,16 @@ class Oara_Network_Publisher_Amazon extends Oara_Network {
 	 * @return Oara_Network_Publisher_Amazon
 	 */
 	public function __construct($credentials) {
+            
+                /*
+                 * If the network was specified in the credentials file, we'll use
+                 * that; otherwise, we'll use the value from the network constant.
+                 * Note the use of 'static' which allows us to override the network
+                 * constant in subclasses
+                 */
+                if (empty($credentials['network'])) {
+                    $credentials['network'] = static::NETWORK;
+                }
 		$this->_credentials = $credentials;
 
 		self::logIn();

--- a/Oara/Network/Publisher/Amazon/Ca.php
+++ b/Oara/Network/Publisher/Amazon/Ca.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Export Class
+ *
+ * @author     Aaron Smith
+ * @category   Oara_Network_Publisher_Amazon
+ * @copyright  Mighty Technologies, LLC
+ * @version    Release: 01.00
+ *
+ */
+
+class Oara_Network_Publisher_Amazon_Ca extends Oara_Network_Publisher_Amazon {
+    /**
+     * The network to use
+     */
+    const NETWORK = 'ca';
+}

--- a/Oara/Network/Publisher/Amazon/Cn.php
+++ b/Oara/Network/Publisher/Amazon/Cn.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Export Class
+ *
+ * @author     Aaron Smith
+ * @category   Oara_Network_Publisher_Amazon
+ * @copyright  Mighty Technologies, LLC
+ * @version    Release: 01.00
+ *
+ */
+
+class Oara_Network_Publisher_Amazon_Cn extends Oara_Network_Publisher_Amazon {
+    /**
+     * The network to use
+     */
+    const NETWORK = 'cn';
+}

--- a/Oara/Network/Publisher/Amazon/De.php
+++ b/Oara/Network/Publisher/Amazon/De.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Export Class
+ *
+ * @author     Aaron Smith
+ * @category   Oara_Network_Publisher_Amazon
+ * @copyright  Mighty Technologies, LLC
+ * @version    Release: 01.00
+ *
+ */
+
+class Oara_Network_Publisher_Amazon_De extends Oara_Network_Publisher_Amazon {
+    /**
+     * The network to use
+     */
+    const NETWORK = 'de';
+}

--- a/Oara/Network/Publisher/Amazon/Es.php
+++ b/Oara/Network/Publisher/Amazon/Es.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Export Class
+ *
+ * @author     Aaron Smith
+ * @category   Oara_Network_Publisher_Amazon
+ * @copyright  Mighty Technologies, LLC
+ * @version    Release: 01.00
+ *
+ */
+
+class Oara_Network_Publisher_Amazon_Es extends Oara_Network_Publisher_Amazon {
+    /**
+     * The network to use
+     */
+    const NETWORK = 'es';
+}

--- a/Oara/Network/Publisher/Amazon/It.php
+++ b/Oara/Network/Publisher/Amazon/It.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Export Class
+ *
+ * @author     Aaron Smith
+ * @category   Oara_Network_Publisher_Amazon
+ * @copyright  Mighty Technologies, LLC
+ * @version    Release: 01.00
+ *
+ */
+
+class Oara_Network_Publisher_Amazon_It extends Oara_Network_Publisher_Amazon {
+    /**
+     * The network to use
+     */
+    const NETWORK = 'it';
+}

--- a/Oara/Network/Publisher/Amazon/Jp.php
+++ b/Oara/Network/Publisher/Amazon/Jp.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Export Class
+ *
+ * @author     Aaron Smith
+ * @category   Oara_Network_Publisher_Amazon
+ * @copyright  Mighty Technologies, LLC
+ * @version    Release: 01.00
+ *
+ */
+
+class Oara_Network_Publisher_Amazon_Jp extends Oara_Network_Publisher_Amazon {
+    /**
+     * The network to use
+     */
+    const NETWORK = 'jp';
+}

--- a/Oara/Network/Publisher/Amazon/Uk.php
+++ b/Oara/Network/Publisher/Amazon/Uk.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Export Class
+ *
+ * @author     Aaron Smith
+ * @category   Oara_Network_Publisher_Amazon
+ * @copyright  Mighty Technologies, LLC
+ * @version    Release: 01.00
+ *
+ */
+
+class Oara_Network_Publisher_Amazon_Uk extends Oara_Network_Publisher_Amazon {
+    /**
+     * The network to use
+     */
+    const NETWORK = 'uk';
+}

--- a/Oara/Network/Publisher/Amazon/Us.php
+++ b/Oara/Network/Publisher/Amazon/Us.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Export Class
+ *
+ * @author     Aaron Smith
+ * @category   Oara_Network_Publisher_Amazon
+ * @copyright  Mighty Technologies, LLC
+ * @version    Release: 01.00
+ *
+ */
+
+class Oara_Network_Publisher_Amazon_Us extends Oara_Network_Publisher_Amazon {
+    /**
+     * The network to use
+     */
+    const NETWORK = 'us';
+}

--- a/examples/credentials.ini.sample
+++ b/examples/credentials.ini.sample
@@ -204,6 +204,38 @@ amazon.password = ''
 ;Network we are going to log in: uk, es, us, ca, de, fr, it, jp, cn.
 amazon.network = ''
 
+;------------Amazon (US Only) ------------
+amazon_us.user = ''
+amazon_us.password = ''
+
+;------------Amazon (Canada Only) ------------
+amazon_ca.user = ''
+amazon_ca.password = ''
+
+;------------Amazon (China Only) ------------
+amazon_cn.user = ''
+amazon_cn.password = ''
+
+;------------Amazon (Germany Only) ------------
+amazon_de.user = ''
+amazon_de.password = ''
+
+;------------Amazon (Spain Only) ------------
+amazon_es.user = ''
+amazon_es.password = ''
+
+;------------Amazon (Italy Only) ------------
+amazon_it.user = ''
+amazon_it.password = ''
+
+;------------Amazon (Japan Only) ------------
+amazon_jp.user = ''
+amazon_jp.password = ''
+
+;------------Amazon (UK Only) ------------
+amazon_uk.user = ''
+amazon_uk.password = ''
+
 ;------------Ebay Partner Network (https://ebaypartnernetwork.com/)------------
 
 ;The user name used in Ebay partner network to log in


### PR DESCRIPTION
First of all, thanks for sharing this project! It's definitely a huge time saver for us.

Anyway, I'm not sure if this helps you, but we're Amazon affiliates in multiple countries and so we want to be able to pull data from each country's Amazon site. However, the way the example affjet.php script is set up (which I'm basing my own scripts on), you would need a new configuration file for each country's Amazon site. This seems redundant given that you can otherwise store configuration data from several networks in a single file.

Instead, I propose some very simple Amazon subclasses, each of which would identify the appropriate Amazon network to fetch from. Account information for each country's Amazon could be stored in a single configuration file. Moreover, by subclassing like this, should we want to we could do things like store currency information or account for any differences between the various Amazon sites. 

The code I've contributed should be completely backwards compatible. Note that I've made "us" the default network for all Amazon requests, but this default can easily be changed or removed altogether.

To use my changes, one would simply add configuration values for the appropriate Amazon accounts (e.g., "amazon_us.user/amazon_us.password" and run the script like this:
php affjet.php -s 12/02/2014 -e 12/02/2014 -n Amazon_Us

Thanks again!