### PR TITLE
Transaction date for Skimlinks has the same format as other networks

### DIFF
--- a/Oara/Network/Publisher/Skimlinks.php
+++ b/Oara/Network/Publisher/Skimlinks.php
@@ -221,7 +221,8 @@ class Oara_Network_Publisher_Skimlinks extends Oara_Network {
 
 			$transaction['merchantId'] = $i["merchantID"];
 			$transaction['unique_id'] =  $i["commissionID"];
-			$transaction['date'] = $i["date"];
+			$transactionDate = new Zend_Date($i["date"], 'YYYY-MM-DD', 'en');
+			$transaction['date'] = $transactionDate->toString("yyyy-MM-dd HH:mm:ss");
 			$transaction['amount'] = (double)$i["orderValue"]/100;
 			$transaction['commission'] = (double)$i["commissionValue"]/100;
 			$transactionStatus = $i["status"];


### PR DESCRIPTION
All networks report the transaction in the format of "yyyy-MM-dd HH:mm:ss".
The only exception seems to be SkimLinks, which use the default format
received from the network, which happens to be 'YYYY-MM-DD'. I used the
formatting logic from Amazon, in order to achieve the same result.