### PR TITLE
Amazon: idbox_store_id => idbox_tracking_id

### DIFF
--- a/Oara/Curl/Access.php
+++ b/Oara/Curl/Access.php
@@ -165,7 +165,7 @@ class Oara_Curl_Access {
 			$ch = curl_init ();
 
 			$options = $this->_options;
-			$options [CURLOPT_URL] = str_replace ( "/publisher/..", "", $location );
+			$options [CURLOPT_URL] = trim(str_replace ( "/publisher/..", "", $location ));
 			$options [CURLOPT_HEADER] = true;
 			$options [CURLOPT_FOLLOWLOCATION] = false;
 

--- a/Oara/Network/Advertiser/CommissionJunction.php
+++ b/Oara/Network/Advertiser/CommissionJunction.php
@@ -297,7 +297,7 @@ class Oara_Network_Advertiser_CommissionJunction extends Oara_Network {
 		*/
 		$urls[] = new Oara_Curl_Request('https://members.cj.com/member/'.$this->_memberId.'/accounts/advertiser/listmypublishers.do?&download=Go&format=CSV', array());
 		$exportReport = $this->_client->get($urls);
-		if (!preg_match("/Sorry, No Results Found\./", $exportReport[0], $matches)) {
+		if (!preg_match('/Sorry, No Results Found\./', $exportReport[0], $matches)) {
 			$exportData = str_getcsv($exportReport[0], "\n");
 			$merchantReportList = Array();
 			$num = count($exportData);
@@ -319,7 +319,7 @@ class Oara_Network_Advertiser_CommissionJunction extends Oara_Network {
 		$urls = array();
 		$urls[] = new Oara_Curl_Request('https://members.cj.com/member/cj/publisher/paymentStatus', array());
 		$exportReport = $this->_client->get($urls);
-		if (preg_match("/\/publisher\/getpublisherpaymenthistory\.do/", $exportReport[0], $matches)) {
+		if (preg_match('/\/publisher\/getpublisherpaymenthistory\.do/', $exportReport[0], $matches)) {
 			$urls = array();
 			$valuesFromExport = $this->_exportPaymentParameters;
 			$urls[] = new Oara_Curl_Request('https://members.cj.com/member/'.$this->_memberId.'/publisher/getpublisherpaymenthistory.do?', $valuesFromExport);

--- a/Oara/Network/Publisher/AffiliateGateway.php
+++ b/Oara/Network/Publisher/AffiliateGateway.php
@@ -229,9 +229,9 @@ class Oara_Network_Publisher_AffiliateGateway extends Oara_Network {
 				$obj = array();
 				$date = new Zend_Date($paymentExportArray[1], "dd/MM/yyyy");
 				$obj['date'] = $date->toString("yyyy-MM-dd HH:mm:ss");
-				$obj['pid'] = preg_replace("/[^0-9\.,]/", "", $paymentExportArray[0]);
+				$obj['pid'] = preg_replace('/[^0-9\.,]/', "", $paymentExportArray[0]);
 				$obj['method'] = 'BACS';
-				$value = preg_replace("/[^0-9\.,]/", "", $paymentExportArray[8]);
+				$value = preg_replace('/[^0-9\.,]/', "", $paymentExportArray[8]);
 				$obj['value'] = Oara_Utilities::parseDouble($value);
 				$paymentHistory[] = $obj;
 			}

--- a/Oara/Network/Publisher/Afilio.php
+++ b/Oara/Network/Publisher/Afilio.php
@@ -159,8 +159,8 @@ class Oara_Network_Publisher_Afilio extends Oara_Network {
 					throw new Exception ( "New status found {$transactionExportArray [7]}" );
 				}
 				
-				$transaction ['amount'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $transactionExportArray [6] ) );
-				$transaction ['commission'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $transactionExportArray [6] ) );
+				$transaction ['amount'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $transactionExportArray [6] ) );
+				$transaction ['commission'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $transactionExportArray [6] ) );
 				
 				$totalTransactions [] = $transaction;
 			}

--- a/Oara/Network/Publisher/Amazon.php
+++ b/Oara/Network/Publisher/Amazon.php
@@ -225,10 +225,11 @@ class Oara_Network_Publisher_Amazon extends Oara_Network {
 		//If not login properly the construct launch an exception
 		$connection = false;
 		$urls = array();
-		$urls[] = new Oara_Curl_Request($this->_networkServer."/gp/associates/network/main.html", array());
+		$urls[] = new Oara_Curl_Request($this->_networkServer."/gp/associates/network/reports/main.html", array());
 		$exportReport = $this->_client->get($urls);
 
 		if (preg_match("/logout%26openid.ns/", $exportReport[0])) {
+
 			$dom = new Zend_Dom_Query($exportReport[0]);
 			$idBox = array();
 			$results = $dom->query('select[name="idbox_tracking_id"]');
@@ -248,12 +249,23 @@ class Oara_Network_Publisher_Amazon extends Oara_Network {
 				}
 			}
 
+			$results = $dom->query('input[name="combinedReports"]');
+			foreach($results as $n) {
+				if ($n->getAttribute('checked') === 'checked') {
+					// Combined reports have been selected, use an empty idBox -> download data only once
+					$idBox = array('');
+					break;
+				}
+			}
+
+			// Use idBox only for US
 			$this->_idBox = $idBox;
 			$connection = true;
 		}
 
 		return $connection;
 	}
+
 	/**
 	 * (non-PHPdoc)
 	 * @see library/Oara/Network/Oara_Network_Publisher_Interface#getMerchantList()

--- a/Oara/Network/Publisher/Amazon.php
+++ b/Oara/Network/Publisher/Amazon.php
@@ -231,7 +231,7 @@ class Oara_Network_Publisher_Amazon extends Oara_Network {
 		if (preg_match("/logout%26openid.ns/", $exportReport[0])) {
 			$dom = new Zend_Dom_Query($exportReport[0]);
 			$idBox = array();
-			$results = $dom->query('select[name="idbox_store_id"]');
+			$results = $dom->query('select[name="idbox_tracking_id"]');
 			$count = count($results);
 			if ($count == 0) {
 				$idBox[] = "";
@@ -317,7 +317,7 @@ class Oara_Network_Publisher_Amazon extends Oara_Network {
 		$valuesFromExport[] = new Oara_Curl_Parameter('endDay', $endDate->toString("d"));
 		$valuesFromExport[] = new Oara_Curl_Parameter('endMonth', (int) $endDate->toString("M") - 1);
 		$valuesFromExport[] = new Oara_Curl_Parameter('endYear', $endDate->toString("yyyy"));
-		$valuesFromExport[] = new Oara_Curl_Parameter('idbox_store_id', $id);
+		$valuesFromExport[] = new Oara_Curl_Parameter('idbox_tracking_id', $id);
 
 		$urls = array();
 		$urls[] = new Oara_Curl_Request($this->_networkServer."/gp/associates/network/reports/report.html?", $valuesFromExport);
@@ -378,7 +378,7 @@ class Oara_Network_Publisher_Amazon extends Oara_Network {
 		foreach ($this->_idBox as $id) {
 			$urls = array();
 			$paymentExport = array();
-			$paymentExport[] = new Oara_Curl_Parameter('idbox_store_id', $id);
+			$paymentExport[] = new Oara_Curl_Parameter('idbox_tracking_id', $id);
 			$urls[] = new Oara_Curl_Request($this->_networkServer."/gp/associates/network/your-account/payment-history.html?", $paymentExport);
 			$exportReport = $this->_client->get($urls);
 			$dom = new Zend_Dom_Query($exportReport[0]);

--- a/Oara/Network/Publisher/Amazon.php
+++ b/Oara/Network/Publisher/Amazon.php
@@ -396,7 +396,7 @@ class Oara_Network_Publisher_Amazon extends Oara_Network {
 					$obj['date'] = $paymentDate->toString("yyyy-MM-dd HH:mm:ss");
 					$obj['pid'] = ($paymentDate->toString("yyyyMMdd").substr((string) base_convert(md5($id), 16, 10), 0, 5));
 					$obj['method'] = 'BACS';
-					if (preg_match("/[0-9]*,?[0-9]*\.?[0-9]+/", $paymentExportArray[4], $matches)) {
+					if (preg_match('/[0-9]*,?[0-9]*\.?[0-9]+/', $paymentExportArray[4], $matches)) {
 						$obj['value'] = Oara_Utilities::parseDouble($matches[0]);
 						$paymentHistory[] = $obj;
 					}

--- a/Oara/Network/Publisher/AutoEurope.php
+++ b/Oara/Network/Publisher/AutoEurope.php
@@ -77,7 +77,7 @@ class Oara_Network_Publisher_AutoEurope extends Oara_Network {
 		$urls = array ();
 		$urls [] = new Oara_Curl_Request ( 'https://www.auto-europe.co.uk/afftools/index.cfm', array () );
 		$exportReport = $this->_client->get ( $urls );
-		if (preg_match ( "/logout\.cfm/", $exportReport [0], $matches )) {
+		if (preg_match ( '/logout\.cfm/', $exportReport [0], $matches )) {
 			$connection = true;
 		}
 		return $connection;

--- a/Oara/Network/Publisher/AvantLink.php
+++ b/Oara/Network/Publisher/AvantLink.php
@@ -169,8 +169,8 @@ class Oara_Network_Publisher_AvantLink extends Oara_Network {
 				}
 
 				$transaction['status'] = Oara_Utilities::STATUS_CONFIRMED;
-				$transaction['amount'] = Oara_Utilities::parseDouble(preg_replace("/[^0-9\.,]/", "", $transactionExportArray[6]));
-				$transaction['commission'] = Oara_Utilities::parseDouble(preg_replace("/[^0-9\.,]/", "", $transactionExportArray[7]));
+				$transaction['amount'] = Oara_Utilities::parseDouble(preg_replace('/[^0-9\.,]/', "", $transactionExportArray[6]));
+				$transaction['commission'] = Oara_Utilities::parseDouble(preg_replace('/[^0-9\.,]/', "", $transactionExportArray[7]));
 				$totalTransactions[] = $transaction;
 			}
 		}

--- a/Oara/Network/Publisher/BTGuard.php
+++ b/Oara/Network/Publisher/BTGuard.php
@@ -126,7 +126,7 @@ class Oara_Network_Publisher_BTGuard extends Oara_Network {
 					$transactionLineArray = str_getcsv($exportData[$z], ";");
 					$numberTransactions = (int)$transactionLineArray[2];
 					if ($numberTransactions != 0){
-						$commission = preg_replace("/[^0-9\.,]/", "", $transactionLineArray[3]);
+						$commission = preg_replace('/[^0-9\.,]/', "", $transactionLineArray[3]);
 						$commission = ((double)$commission)/$numberTransactions;
 						for($y=0; $y < $numberTransactions; $y++){
 							$transaction = Array();
@@ -170,7 +170,7 @@ class Oara_Network_Publisher_BTGuard extends Oara_Network {
 				$obj['date'] = $paymentDate->toString("yyyy-MM-dd HH:mm:ss");
 				$obj['pid'] = $paymentDate->toString("yyyyMMdd");
 				$obj['method'] = 'BACS';
-				if (preg_match("/[-+]?[0-9]*,?[0-9]*\.?[0-9]+/", $paymentExportArray[2], $matches)) {
+				if (preg_match('/[-+]?[0-9]*,?[0-9]*\.?[0-9]+/', $paymentExportArray[2], $matches)) {
 					$obj['value'] = Oara_Utilities::parseDouble($matches[0]);
 				} else {
 					throw new Exception("Problem reading payments");

--- a/Oara/Network/Publisher/Bol.php
+++ b/Oara/Network/Publisher/Bol.php
@@ -62,7 +62,7 @@ class Oara_Network_Publisher_Bol extends Oara_Network {
 		$urls[] = new Oara_Curl_Request('https://partnerprogramma.bol.com/partner/index.do?', array());
 		$exportReport = $this->_client->get($urls);
 
-		if (preg_match("/partner\/logout\.do/", $exportReport[0], $match)) {
+		if (preg_match('/partner\/logout\.do/', $exportReport[0], $match)) {
 			$connection = true;
 		}
 		return $connection;

--- a/Oara/Network/Publisher/CgtAffiliate.php
+++ b/Oara/Network/Publisher/CgtAffiliate.php
@@ -133,8 +133,8 @@ class Oara_Network_Publisher_CgtAffiliate extends Oara_Network {
 				$transaction['status'] = Oara_Utilities::STATUS_CONFIRMED;
 			}
 				
-			$transaction['amount'] = preg_replace("/[^0-9\.,]/", "", $transactionExportArray[2]);
-			$transaction['commission'] = preg_replace("/[^0-9\.,]/", "", $transactionExportArray[2]);
+			$transaction['amount'] = preg_replace('/[^0-9\.,]/', "", $transactionExportArray[2]);
+			$transaction['commission'] = preg_replace('/[^0-9\.,]/', "", $transactionExportArray[2]);
 			$totalTransactions[] = $transaction;
 		}
 		return $totalTransactions;

--- a/Oara/Network/Publisher/Chegg.php
+++ b/Oara/Network/Publisher/Chegg.php
@@ -106,7 +106,7 @@ class Oara_Network_Publisher_Chegg extends Oara_Network {
 		$exportReport = $this->_client->get($urls);
 		echo $exportReport[0];
 		
-		if (preg_match("/Welcome\/Logout\.aspx/", $exportReport[0])) {
+		if (preg_match('/Welcome\/Logout\.aspx/', $exportReport[0])) {
 			$connection = true;
 		}
 		return $connection;

--- a/Oara/Network/Publisher/ClixGalore.php
+++ b/Oara/Network/Publisher/ClixGalore.php
@@ -211,10 +211,10 @@ class Oara_Network_Publisher_ClixGalore extends Oara_Network {
 						$transaction['status'] = Oara_Utilities::STATUS_DECLINED;
 					}
 
-					if (preg_match("/[0-9]*,?[0-9]*\.?[0-9]+/", $transactionExportArray[4], $matches)) {
+					if (preg_match('/[0-9]*,?[0-9]*\.?[0-9]+/', $transactionExportArray[4], $matches)) {
 						$transaction['amount'] = Oara_Utilities::parseDouble($matches[0]);
 					}
-					if (preg_match("/[0-9]*,?[0-9]*\.?[0-9]+/", $transactionExportArray[5], $matches)) {
+					if (preg_match('/[0-9]*,?[0-9]*\.?[0-9]+/', $transactionExportArray[5], $matches)) {
 						$transaction['commission'] = Oara_Utilities::parseDouble($matches[0]);
 					}
 
@@ -267,7 +267,7 @@ class Oara_Network_Publisher_ClixGalore extends Oara_Network {
 					$obj['date'] = $paymentDate->toString("yyyy-MM-dd HH:mm:ss");
 					$obj['pid'] = $paymentDate->toString("yyyyMMdd");
 					$obj['method'] = 'BACS';
-					if (preg_match("/[-+]?[0-9]*,?[0-9]*\.?[0-9]+/", $paymentExportArray[2], $matches)) {
+					if (preg_match('/[-+]?[0-9]*,?[0-9]*\.?[0-9]+/', $paymentExportArray[2], $matches)) {
 						$obj['value'] = Oara_Utilities::parseDouble($matches[0]);
 					} else {
 						throw new Exception("Problem reading payments");

--- a/Oara/Network/Publisher/CommissionJunction.php
+++ b/Oara/Network/Publisher/CommissionJunction.php
@@ -324,7 +324,7 @@ class Oara_Network_Publisher_CommissionJunction extends Oara_Network {
 		$urls[] = new Oara_Curl_Request('https://members.cj.com/member/'.$this->_memberId.'/publisher/accounts/listmyadvertisers.do', array());
 		$exportReport = $this->_client->get($urls);
 		
-		if (!preg_match("/Sorry, No Results Found\./", $exportReport[0], $matches)) {
+		if (!preg_match('/Sorry, No Results Found\./', $exportReport[0], $matches)) {
 			$urls = array();
 			$urls[] = new Oara_Curl_Request('https://members.cj.com/member/'.$this->_memberId.'/publisher/accounts/listmyadvertisers.do', $valuesFromExport);
 			$exportReport = $this->_client->post($urls);
@@ -348,7 +348,7 @@ class Oara_Network_Publisher_CommissionJunction extends Oara_Network {
 		$urls = array();
 		$urls[] = new Oara_Curl_Request('https://members.cj.com/member/cj/publisher/paymentStatus', array());
 		$exportReport = $this->_client->get($urls);
-		if (preg_match("/\/publisher\/getpublisherpaymenthistory\.do/", $exportReport[0], $matches)) {
+		if (preg_match('/\/publisher\/getpublisherpaymenthistory\.do/', $exportReport[0], $matches)) {
 			$urls = array();
 			$valuesFromExport = $this->_exportPaymentParameters;
 			$urls[] = new Oara_Curl_Request('https://members.cj.com/member/'.$this->_memberId.'/publisher/getpublisherpaymenthistory.do?', $valuesFromExport);

--- a/Oara/Network/Publisher/Ebay.php
+++ b/Oara/Network/Publisher/Ebay.php
@@ -199,7 +199,7 @@ class Oara_Network_Publisher_Ebay extends Oara_Network {
 				$obj['date'] = $paymentDate->toString("yyyy-MM-dd HH:mm:ss");
 				$obj['pid'] = $paymentDate->toString("yyyyMMdd");
 				$obj['method'] = 'BACS';
-				if (preg_match("/[-+]?[0-9]*,?[0-9]*\.?[0-9]+/", $paymentExportArray[2], $matches)) {
+				if (preg_match('/[-+]?[0-9]*,?[0-9]*\.?[0-9]+/', $paymentExportArray[2], $matches)) {
 					$obj['value'] = Oara_Utilities::parseDouble($matches[0]);
 				} else {
 					throw new Exception("Problem reading payments");

--- a/Oara/Network/Publisher/Etrader.php
+++ b/Oara/Network/Publisher/Etrader.php
@@ -138,12 +138,12 @@ class Oara_Network_Publisher_Etrader extends Oara_Network {
 				$transaction ['status'] = Oara_Utilities::STATUS_CONFIRMED;
 				
 				if ($transactionDetail[3] != null){
-					preg_match("/[-+]?[0-9]*\.?[0-9]+/", $transactionDetail[3], $match);
+					preg_match('/[-+]?[0-9]*\.?[0-9]+/', $transactionDetail[3], $match);
 					$transaction['amount'] = (double)$match[0];
 					$transaction['commission'] = (double)$match[0];
 					
 				} else if ($transactionDetail[4] != null){
-					preg_match("/[-+]?[0-9]*\.?[0-9]+/", $transactionDetail[4], $match);
+					preg_match('/[-+]?[0-9]*\.?[0-9]+/', $transactionDetail[4], $match);
 					$transaction['amount'] = (double)$match[0];
 					$transaction['commission'] = (double)$match[0];
 				}

--- a/Oara/Network/Publisher/FashionTraffic.php
+++ b/Oara/Network/Publisher/FashionTraffic.php
@@ -187,10 +187,10 @@ class Oara_Network_Publisher_FashionTraffic extends Oara_Network {
 					throw new Exception("Status {$transactionExportArray[10]} unknown");
 				}
 
-				if (preg_match("/[-+]?[0-9]*\.?[0-9]+/", $transactionExportArray[9], $match)){
+				if (preg_match('/[-+]?[0-9]*\.?[0-9]+/', $transactionExportArray[9], $match)){
 					$transaction['amount'] = (double)$match[0];
 				}
-				if (preg_match("/[-+]?[0-9]*\.?[0-9]+/", $transactionExportArray[9], $match)){
+				if (preg_match('/[-+]?[0-9]*\.?[0-9]+/', $transactionExportArray[9], $match)){
 					$transaction['commission'] = (double)$match[0];
 				}
 				$totalTransactions[] = $transaction;

--- a/Oara/Network/Publisher/FoxTransfer.php
+++ b/Oara/Network/Publisher/FoxTransfer.php
@@ -126,8 +126,8 @@ class Oara_Network_Publisher_FoxTransfer extends Oara_Network {
 				throw new Exception("New status found");
 			}
 			
-			$transaction['amount'] = Oara_Utilities::parseDouble(preg_replace("/[^0-9\.,]/", "", $transactionExportArray[10]));
-			$transaction['commission'] = Oara_Utilities::parseDouble(preg_replace("/[^0-9\.,]/", "", $transactionExportArray[13]));
+			$transaction['amount'] = Oara_Utilities::parseDouble(preg_replace('/[^0-9\.,]/', "", $transactionExportArray[10]));
+			$transaction['commission'] = Oara_Utilities::parseDouble(preg_replace('/[^0-9\.,]/', "", $transactionExportArray[13]));
 
 			$totalTransactions[] = $transaction;
 

--- a/Oara/Network/Publisher/HavasMedia.php
+++ b/Oara/Network/Publisher/HavasMedia.php
@@ -247,7 +247,7 @@ class Oara_Network_Publisher_HavasMedia extends Oara_Network {
 		$urls = array();
 		$urls[] = new Oara_Curl_Request('http://publisher.tradedoubler.com/pan/aReport3Selection.action?reportName=aAffiliateProgramOverviewReport', array());
 		$exportReport = $this->_client->get($urls);
-		if (preg_match("/\(([a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2})\)/", $exportReport[0], $match)) {
+		if (preg_match('/\(([a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2})\)/', $exportReport[0], $match)) {
 			$this->_dateFormat = $match[1];
 		}
 
@@ -413,9 +413,9 @@ class Oara_Network_Publisher_HavasMedia extends Oara_Network {
 
 	public function checkReportError($content, $request, $try = 0) {
 
-		if (preg_match("/\/report\/published\/aAffiliateEventBreakdownReport/", $content, $matches)) {
+		if (preg_match('/\/report\/published\/aAffiliateEventBreakdownReport/', $content, $matches)) {
 			//report too big, we have to download it and read it
-			if (preg_match("/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/", $content, $matches)) {
+			if (preg_match('/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/', $content, $matches)) {
 
 				$file = "http://publisher.tradedoubler.com".$matches[0];
 				$newfile = realpath ( dirname ( COOKIES_BASE_DIR ) ) . '/pdf/'.$matches[2].'.zip';
@@ -494,7 +494,7 @@ class Oara_Network_Publisher_HavasMedia extends Oara_Network {
 						$obj = array();
 
 						$paymentLine = $paymentLines->item($i)->nodeValue;
-						$value = preg_replace("/[^0-9\.,]/", "", substr($paymentLine, 10));
+						$value = preg_replace('/[^0-9\.,]/', "", substr($paymentLine, 10));
 
 						$date = self::toDate(substr($paymentLine, 0, 10));
 

--- a/Oara/Network/Publisher/HideMyAss.php
+++ b/Oara/Network/Publisher/HideMyAss.php
@@ -181,11 +181,11 @@ class Oara_Network_Publisher_HideMyAss extends Oara_Network {
 				//unset($transactionDate);
 				$transaction['status'] = Oara_Utilities::STATUS_CONFIRMED;
 
-				if (preg_match("/[-+]?[0-9]*\.?[0-9]+/", $transactionExportArray[8], $match)){
+				if (preg_match('/[-+]?[0-9]*\.?[0-9]+/', $transactionExportArray[8], $match)){
 					$transaction['amount'] = (double)$match[0];
 				}
 
-				if (preg_match("/[-+]?[0-9]*\.?[0-9]+/", $transactionExportArray[10], $match)){
+				if (preg_match('/[-+]?[0-9]*\.?[0-9]+/', $transactionExportArray[10], $match)){
 					$transaction['commission'] = (double)$match[0];
 				}
 

--- a/Oara/Network/Publisher/Invia.php
+++ b/Oara/Network/Publisher/Invia.php
@@ -270,7 +270,7 @@ echo $html;
 				$status = $transactionExportArray [4];
 				if ($status == "Zaplaceno") {
 					$transaction ['status'] = Oara_Utilities::STATUS_CONFIRMED;
-				} else if ($status == "Neprodáno") {
+				} else if ($status == "Neprodï¿½no") {
 					$transaction ['status'] = Oara_Utilities::STATUS_PENDING;
 				} else if ($status == "Storno") {
 					$transaction ['status'] = Oara_Utilities::STATUS_DECLINED;
@@ -279,8 +279,8 @@ echo $html;
 				}
 				
 				
-				$transaction ['amount'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $transactionExportArray [6] ) );
-				$transaction ['commission'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $transactionExportArray [6] ) );
+				$transaction ['amount'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $transactionExportArray [6] ) );
+				$transaction ['commission'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $transactionExportArray [6] ) );
 				
 				
 				$transaction ['merchantId'] = 1;

--- a/Oara/Network/Publisher/LinkShare.php
+++ b/Oara/Network/Publisher/LinkShare.php
@@ -103,7 +103,7 @@ class Oara_Network_Publisher_LinkShare extends Oara_Network {
 		$result = $this->_client->get ( $urls );
 		
 		// Check if the credentials are right
-		if (preg_match ( "/https:\/\/cli\.linksynergy\.com\/cli\/common\/logout\.php/", $result [0], $matches )) {
+		if (preg_match ( '/https:\/\/cli\.linksynergy\.com\/cli\/common\/logout\.php/', $result [0], $matches )) {
 			
 			$urls = array ();
 			$urls [] = new Oara_Curl_Request ( 'https://cli.linksynergy.com/cli/publisher/my_account/marketingChannels.php', array () );

--- a/Oara/Network/Publisher/Mall.php
+++ b/Oara/Network/Publisher/Mall.php
@@ -248,7 +248,7 @@ class Oara_Network_Publisher_Mall extends Oara_Network {
 		$urls = array();
 		$urls[] = new Oara_Curl_Request('http://publisher.tradedoubler.com/pan/aReport3Selection.action?reportName=aAffiliateProgramOverviewReport', array());
 		$exportReport = $this->_client->get($urls);
-		if (preg_match("/\(([a-zA-Z]{0,2}[\/\.-][a-zA-Z]{0,2}[\/\.-][a-zA-Z]{0,2})\)/", $exportReport[0], $match)) {
+		if (preg_match('/\(([a-zA-Z]{0,2}[\/\.-][a-zA-Z]{0,2}[\/\.-][a-zA-Z]{0,2})\)/', $exportReport[0], $match)) {
 			$this->_dateFormat = $match[1];
 		}
 
@@ -342,9 +342,9 @@ class Oara_Network_Publisher_Mall extends Oara_Network {
 
 	public function checkReportError($content, $request, $try = 0) {
 
-		if (preg_match("/\/report\/published\/aAffiliateEventBreakdownReport/", $content, $matches)) {
+		if (preg_match('/\/report\/published\/aAffiliateEventBreakdownReport/', $content, $matches)) {
 			//report too big, we have to download it and read it
-			if (preg_match("/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/", $content, $matches)) {
+			if (preg_match('/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/', $content, $matches)) {
 
 				$file = "http://publisher.tradedoubler.com".$matches[0];
 				$newfile = realpath ( dirname ( COOKIES_BASE_DIR ) ) . '/pdf/'.$matches[2].'.zip';
@@ -423,7 +423,7 @@ class Oara_Network_Publisher_Mall extends Oara_Network {
 						$obj = array();
 
 						$paymentLine = $paymentLines->item($i)->nodeValue;
-						$value = preg_replace("/[^0-9\.,]/", "", substr($paymentLine, 10));
+						$value = preg_replace('/[^0-9\.,]/', "", substr($paymentLine, 10));
 
 						$date = self::toDate(substr($paymentLine, 0, 10));
 

--- a/Oara/Network/Publisher/MyPcBackUp.php
+++ b/Oara/Network/Publisher/MyPcBackUp.php
@@ -119,10 +119,10 @@ class Oara_Network_Publisher_MyPcBackUP extends Oara_Network {
 			$transaction['date'] = $transactionDate->toString("yyyy-MM-dd HH:mm:ss");
 			unset($transactionDate);
 
-			if (preg_match("/[-+]?[0-9]*\.?[0-9]+/", $transactionExportArray[5], $match)){
+			if (preg_match('/[-+]?[0-9]*\.?[0-9]+/', $transactionExportArray[5], $match)){
 				$transaction['amount'] = (double)$match[0];
 			}
-			if (preg_match("/[-+]?[0-9]*\.?[0-9]+/", $transactionExportArray[5], $match)){
+			if (preg_match('/[-+]?[0-9]*\.?[0-9]+/', $transactionExportArray[5], $match)){
 				$transaction['commission'] = (double)$match[0];
 			}
 			if ($transactionExportArray[4] == "Sale"){
@@ -164,9 +164,9 @@ class Oara_Network_Publisher_MyPcBackUP extends Oara_Network {
 					$obj = array();
 					$date = new Zend_Date($paymentExportArray[14], "MM/dd/yyyy");
 					$obj['date'] = $date->toString("yyyy-MM-dd HH:mm:ss");
-					$obj['pid'] = preg_replace("/[^0-9\.,]/", "", $paymentExportArray[14]);
+					$obj['pid'] = preg_replace('/[^0-9\.,]/', "", $paymentExportArray[14]);
 					$obj['method'] = $paymentExportArray[16];
-					$value = preg_replace("/[^0-9\.,]/", "", $paymentExportArray[12]);
+					$value = preg_replace('/[^0-9\.,]/', "", $paymentExportArray[12]);
 					
 					$obj['value'] = Oara_Utilities::parseDouble($value);
 					$paymentHistory[] = $obj;

--- a/Oara/Network/Publisher/NetAffiliation.php
+++ b/Oara/Network/Publisher/NetAffiliation.php
@@ -70,7 +70,7 @@ class Oara_Network_Publisher_NetAffiliation extends Oara_Network {
 
 		$cookieContent = file_get_contents($cookieLocalion);
 		$serverNumber = null;
-		if (preg_match("/www(.)\.netaffiliation\.com/", $cookieContent, $matches)) {
+		if (preg_match('/www(.)\.netaffiliation\.com/', $cookieContent, $matches)) {
 			$this->_serverNumber = $matches[1];
 		}
 

--- a/Oara/Network/Publisher/Omnicom.php
+++ b/Oara/Network/Publisher/Omnicom.php
@@ -247,7 +247,7 @@ class Oara_Network_Publisher_Omnicom extends Oara_Network {
 		$urls = array();
 		$urls[] = new Oara_Curl_Request('http://publisher.tradedoubler.com/pan/aReport3Selection.action?reportName=aAffiliateProgramOverviewReport', array());
 		$exportReport = $this->_client->get($urls);
-		if (preg_match("/\(([a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2})\)/", $exportReport[0], $match)) {
+		if (preg_match('/\(([a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2})\)/', $exportReport[0], $match)) {
 			$this->_dateFormat = $match[1];
 		}
 
@@ -413,9 +413,9 @@ class Oara_Network_Publisher_Omnicom extends Oara_Network {
 
 	public function checkReportError($content, $request, $try = 0) {
 
-		if (preg_match("/\/report\/published\/aAffiliateEventBreakdownReport/", $content, $matches)) {
+		if (preg_match('/\/report\/published\/aAffiliateEventBreakdownReport/', $content, $matches)) {
 			//report too big, we have to download it and read it
-			if (preg_match("/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/", $content, $matches)) {
+			if (preg_match('/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/', $content, $matches)) {
 
 				$file = "http://publisher.tradedoubler.com".$matches[0];
 				$newfile = realpath ( dirname ( COOKIES_BASE_DIR ) ) . '/pdf/'.$matches[2].'.zip';
@@ -494,7 +494,7 @@ class Oara_Network_Publisher_Omnicom extends Oara_Network {
 						$obj = array();
 
 						$paymentLine = $paymentLines->item($i)->nodeValue;
-						$value = preg_replace("/[^0-9\.,]/", "", substr($paymentLine, 10));
+						$value = preg_replace('/[^0-9\.,]/', "", substr($paymentLine, 10));
 
 						$date = self::toDate(substr($paymentLine, 0, 10));
 

--- a/Oara/Network/Publisher/PayMode.php
+++ b/Oara/Network/Publisher/PayMode.php
@@ -140,7 +140,7 @@ class Oara_Network_Publisher_PayMode extends Oara_Network {
 		$urls[] = new Oara_Curl_Request('https://secure.paymode.com/paymode/home.jsp?', array());
 		$exportReport = $this->_client->get($urls);
 
-		if (preg_match("/paymode\/logout\.jsp/", $exportReport[0], $matches)) {
+		if (preg_match('/paymode\/logout\.jsp/', $exportReport[0], $matches)) {
 
 			$urls = array();
 			$urls[] = new Oara_Curl_Request('https://secure.paymode.com/paymode/reports-pre_commission_history.jsp?', array());
@@ -335,7 +335,7 @@ class Oara_Network_Publisher_PayMode extends Oara_Network {
 						$payment['date'] = $paymentDate->toString("yyyy-MM-dd HH:mm:ss");
 
 						$paymentArray = str_getcsv($tableCsv[3], ";");
-						$payment['value'] = Oara_Utilities::parseDouble(preg_replace("/[^0-9\.,]/", "", $paymentArray[3]));
+						$payment['value'] = Oara_Utilities::parseDouble(preg_replace('/[^0-9\.,]/', "", $paymentArray[3]));
 						$payment['method'] = "BACS";
 						$paymentHistory[] = $payment;
 					}

--- a/Oara/Network/Publisher/PrivateInternetAccess.php
+++ b/Oara/Network/Publisher/PrivateInternetAccess.php
@@ -186,7 +186,7 @@ class Oara_Network_Publisher_PrivateInternetAccess extends Oara_Network {
 				for($z=1; $z < count($exportData)-4; $z++){
 					$transactionLineArray = str_getcsv($exportData[$z], ";");
 					$numberTransactions = (int)$transactionLineArray[1];
-					$commission = preg_replace("/[^0-9\.,]/", "", $transactionLineArray[2]);
+					$commission = preg_replace('/[^0-9\.,]/', "", $transactionLineArray[2]);
 					$commission = ((double)$commission)/$numberTransactions;
 					for($y=0; $y < $numberTransactions; $y++){
 						$transaction = Array();

--- a/Oara/Network/Publisher/Publicidees.php
+++ b/Oara/Network/Publisher/Publicidees.php
@@ -89,7 +89,7 @@ class Oara_Network_Publisher_Publicidees extends Oara_Network {
 		$urls[] = new Oara_Curl_Request('http://affilie.publicidees.com/', array());
 		$exportReport = $this->_client->get($urls);
 
-		if (preg_match("/deconnexion\.php/", $exportReport[0], $matches)) {
+		if (preg_match('/deconnexion\.php/', $exportReport[0], $matches)) {
 			$connection = true;
 		}
 		return $connection;

--- a/Oara/Network/Publisher/SalesMedia.php
+++ b/Oara/Network/Publisher/SalesMedia.php
@@ -215,8 +215,8 @@ class Oara_Network_Publisher_SalesMedia extends Oara_Network {
 				$transactionDate = new Zend_Date ( $transactionExportArray [0], 'MM/dd/yyyy');
 				$transaction ['date'] = $transactionDate->toString ( "yyyy-MM-dd HH:mm:ss" );				
 				$transaction ['status'] = Oara_Utilities::STATUS_CONFIRMED;				
-				$transaction ['amount'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $transactionExportArray [4] ) ); //Wartosc Sprzedazy
-				$transaction ['commission'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $transactionExportArray [6] ) ); //Wyplata
+				$transaction ['amount'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $transactionExportArray [4] ) ); //Wartosc Sprzedazy
+				$transaction ['commission'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $transactionExportArray [6] ) ); //Wyplata
 				
 				
 				$totalTransactions [] = $transaction;

--- a/Oara/Network/Publisher/Shuttlefare.php
+++ b/Oara/Network/Publisher/Shuttlefare.php
@@ -189,8 +189,8 @@ class Oara_Network_Publisher_Shuttlefare extends Oara_Network {
 				$transactionDate = new Zend_Date ( $transactionExportArray [5], 'MM/dd/yyyy');
 				$transaction ['date'] = $transactionDate->toString ( "yyyy-MM-dd HH:mm:ss" );				
 				$transaction ['status'] = Oara_Utilities::STATUS_CONFIRMED;				
-				$transaction ['amount'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $transactionExportArray [1] ) );
-				$transaction ['commission'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $transactionExportArray [2] ) );
+				$transaction ['amount'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $transactionExportArray [1] ) );
+				$transaction ['commission'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $transactionExportArray [2] ) );
 				
 				$totalTransactions [] = $transaction;
 				

--- a/Oara/Network/Publisher/SilverTap.php
+++ b/Oara/Network/Publisher/SilverTap.php
@@ -366,7 +366,7 @@ class Oara_Network_Publisher_SilverTap extends Oara_Network {
 						$exit_code = proc_close($pdfReader);
 					}
 
-					if (preg_match_all("/[0-9]*,?[0-9]*\.[0-9]+/", $pdfContent, $matches)) {
+					if (preg_match_all('/[0-9]*,?[0-9]*\.[0-9]+/', $pdfContent, $matches)) {
 						$obj['value'] = Oara_Utilities::parseDouble($matches[0][count($matches[0]) - 1]);
 					} else {
 						throw new Exception('Problem getting value in payments');

--- a/Oara/Network/Publisher/SkyParkSecure.php
+++ b/Oara/Network/Publisher/SkyParkSecure.php
@@ -157,8 +157,8 @@ class Oara_Network_Publisher_SkyParkSecure extends Oara_Network {
 				throw new Exception("New status found");
 			}
 			
-			$transaction['amount'] = Oara_Utilities::parseDouble(preg_replace("/[^0-9\.,]/", "", $booking->sale_price))/1.2;
-			$transaction['commission'] = Oara_Utilities::parseDouble(preg_replace("/[^0-9\.,]/", "",  $booking->commission_affiliate))/1.2;
+			$transaction['amount'] = Oara_Utilities::parseDouble(preg_replace('/[^0-9\.,]/', "", $booking->sale_price))/1.2;
+			$transaction['commission'] = Oara_Utilities::parseDouble(preg_replace('/[^0-9\.,]/', "",  $booking->commission_affiliate))/1.2;
 
 			$totalTransactions[] = $transaction;
 

--- a/Oara/Network/Publisher/SkyScanner.php
+++ b/Oara/Network/Publisher/SkyScanner.php
@@ -108,7 +108,7 @@ class Oara_Network_Publisher_SkyScanner extends Oara_Network {
 		$exportReport = array();
 		$exportReport = $this->_client->get($urls);
 		$dump = var_export($exportReport[0], true);
-		$dump = preg_replace("/ \. /", "", $dump);
+		$dump = preg_replace('/ \. /', "", $dump);
 	    $dump = preg_replace("/\"\\\\0\"/", "", $dump);
 	    $dump = preg_replace("/'/", "", $dump);
 	    

--- a/Oara/Network/Publisher/Smg.php
+++ b/Oara/Network/Publisher/Smg.php
@@ -115,7 +115,7 @@ class Oara_Network_Publisher_Smg extends Oara_Network {
 		$urls[] = new Oara_Curl_Request('https://member.impactradius.co.uk/secure/mediapartner/home/pview.ihtml', array());
 		$exportReport = $this->_newClient->get($urls);
 		$newCheck = false;
-		if (preg_match("/\/logOut\.user/", $exportReport[0], $match)) {
+		if (preg_match('/\/logOut\.user/', $exportReport[0], $match)) {
 			$newCheck = true;
 		}
 
@@ -260,7 +260,7 @@ class Oara_Network_Publisher_Smg extends Oara_Network {
 			$obj['date'] = $date->toString("yyyy-MM-dd HH:mm:ss");
 			$obj['pid'] = $paymentExportArray[0];
 			$obj['method'] = 'BACS';
-			if (preg_match("/[-+]?[0-9]*,?[0-9]*\.?[0-9]+/", $paymentExportArray[6], $matches)) {
+			if (preg_match('/[-+]?[0-9]*,?[0-9]*\.?[0-9]+/', $paymentExportArray[6], $matches)) {
 				$obj['value'] = $filter->filter($matches[0]);
 			} else {
 				throw new Exception("Problem reading payments");

--- a/Oara/Network/Publisher/SportCoverDirect.php
+++ b/Oara/Network/Publisher/SportCoverDirect.php
@@ -158,8 +158,8 @@ class Oara_Network_Publisher_SportCoverDirect extends Oara_Network {
 
 				$date = new Zend_Date($overviewExportArray[0], "dd/MM/yyyy");
 				$transaction['date'] = $date->toString("yyyy-MM-dd HH:mm:ss");
-				$transaction ['amount'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $overviewExportArray[1] ) );
-				$transaction['commission'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $overviewExportArray[1] ) );
+				$transaction ['amount'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $overviewExportArray[1] ) );
+				$transaction['commission'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $overviewExportArray[1] ) );
 				$transaction['status'] = Oara_Utilities::STATUS_CONFIRMED;
 
 				$totalTransactions[] = $transaction;

--- a/Oara/Network/Publisher/Steak.php
+++ b/Oara/Network/Publisher/Steak.php
@@ -247,7 +247,7 @@ class Oara_Network_Publisher_Steak extends Oara_Network {
 		$urls = array();
 		$urls[] = new Oara_Curl_Request('http://publisher.tradedoubler.com/pan/aReport3Selection.action?reportName=aAffiliateProgramOverviewReport', array());
 		$exportReport = $this->_client->get($urls);
-		if (preg_match("/\(([a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2})\)/", $exportReport[0], $match)) {
+		if (preg_match('/\(([a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2})\)/', $exportReport[0], $match)) {
 			$this->_dateFormat = $match[1];
 		}
 
@@ -413,9 +413,9 @@ class Oara_Network_Publisher_Steak extends Oara_Network {
 
 	public function checkReportError($content, $request, $try = 0) {
 
-		if (preg_match("/\/report\/published\/aAffiliateEventBreakdownReport/", $content, $matches)) {
+		if (preg_match('/\/report\/published\/aAffiliateEventBreakdownReport/', $content, $matches)) {
 			//report too big, we have to download it and read it
-			if (preg_match("/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/", $content, $matches)) {
+			if (preg_match('/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/', $content, $matches)) {
 
 				$file = "http://publisher.tradedoubler.com".$matches[0];
 				$newfile = realpath ( dirname ( COOKIES_BASE_DIR ) ) . '/pdf/'.$matches[2].'.zip';
@@ -494,7 +494,7 @@ class Oara_Network_Publisher_Steak extends Oara_Network {
 						$obj = array();
 
 						$paymentLine = $paymentLines->item($i)->nodeValue;
-						$value = preg_replace("/[^0-9\.,]/", "", substr($paymentLine, 10));
+						$value = preg_replace('/[^0-9\.,]/', "", substr($paymentLine, 10));
 
 						$date = self::toDate(substr($paymentLine, 0, 10));
 

--- a/Oara/Network/Publisher/Stream20.php
+++ b/Oara/Network/Publisher/Stream20.php
@@ -247,7 +247,7 @@ class Oara_Network_Publisher_Stream20 extends Oara_Network {
 		$urls = array();
 		$urls[] = new Oara_Curl_Request('http://publisher.tradedoubler.com/pan/aReport3Selection.action?reportName=aAffiliateProgramOverviewReport', array());
 		$exportReport = $this->_client->get($urls);
-		if (preg_match("/\(([a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2})\)/", $exportReport[0], $match)) {
+		if (preg_match('/\(([a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2}[\/\.][a-zA-Z]{0,2})\)/', $exportReport[0], $match)) {
 			$this->_dateFormat = $match[1];
 		}
 
@@ -380,9 +380,9 @@ class Oara_Network_Publisher_Stream20 extends Oara_Network {
 
 	public function checkReportError($content, $request, $try = 0) {
 
-		if (preg_match("/\/report\/published\/aAffiliateEventBreakdownReport/", $content, $matches)) {
+		if (preg_match('/\/report\/published\/aAffiliateEventBreakdownReport/', $content, $matches)) {
 			//report too big, we have to download it and read it
-			if (preg_match("/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/", $content, $matches)) {
+			if (preg_match('/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/', $content, $matches)) {
 
 				$file = "http://publisher.tradedoubler.com".$matches[0];
 				$newfile = realpath ( dirname ( COOKIES_BASE_DIR ) ) . '/pdf/'.$matches[2].'.zip';
@@ -470,7 +470,7 @@ class Oara_Network_Publisher_Stream20 extends Oara_Network {
 						$obj['date'] = $date->toString("yyyy-MM-dd HH:mm:ss");
 						$obj['pid'] = $pid;
 						$obj['method'] = 'BACS';
-						if (preg_match("/[-+]?[0-9]*,?[0-9]*\.?[0-9]+/", substr($paymentLine, 10), $matches)) {
+						if (preg_match('/[-+]?[0-9]*,?[0-9]*\.?[0-9]+/', substr($paymentLine, 10), $matches)) {
 							$obj['value'] = $filter->filter($matches[0]);
 						} else {
 							throw new Exception("Problem reading payments");

--- a/Oara/Network/Publisher/TerraVision.php
+++ b/Oara/Network/Publisher/TerraVision.php
@@ -129,8 +129,8 @@ class Oara_Network_Publisher_TerraVision extends Oara_Network {
 					
 				$transaction['date'] = $dEndDate->toString("yyyy-MM-dd HH:mm:ss");
 		
-				$transaction['amount'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $transactionArray [2] ) );
-				$transaction['commission'] = Oara_Utilities::parseDouble ( preg_replace ( "/[^0-9\.,]/", "", $transactionArray [2] ) );
+				$transaction['amount'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $transactionArray [2] ) );
+				$transaction['commission'] = Oara_Utilities::parseDouble ( preg_replace ( '/[^0-9\.,]/', "", $transactionArray [2] ) );
 		
 				$totalTransactions[] = $transaction;
 			}

--- a/Oara/Network/Publisher/TradeDoubler.php
+++ b/Oara/Network/Publisher/TradeDoubler.php
@@ -248,7 +248,7 @@ class Oara_Network_Publisher_TradeDoubler extends Oara_Network {
 		$urls[] = new Oara_Curl_Request('http://publisher.tradedoubler.com/pan/aReport3Selection.action?reportName=aAffiliateProgramOverviewReport', array());
 		$exportReport = $this->_client->get($urls);
 		
-		if (preg_match("/\(([a-zA-Z]{0,4}[\/\.-][a-zA-Z]{0,4}[\/\.-][a-zA-Z]{0,4})\)/", $exportReport[0], $match)) {
+		if (preg_match('/\(([a-zA-Z]{0,4}[\/\.-][a-zA-Z]{0,4}[\/\.-][a-zA-Z]{0,4})\)/', $exportReport[0], $match)) {
 			$this->_dateFormat = $match[1];
 		}
 
@@ -418,9 +418,9 @@ class Oara_Network_Publisher_TradeDoubler extends Oara_Network {
 
 	public function checkReportError($content, $request, $try = 0) {
 
-		if (preg_match("/\/report\/published\/aAffiliateEventBreakdownReport/", $content, $matches)) {
+		if (preg_match('/\/report\/published\/aAffiliateEventBreakdownReport/', $content, $matches)) {
 			//report too big, we have to download it and read it
-			if (preg_match("/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/", $content, $matches)) {
+			if (preg_match('/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/', $content, $matches)) {
 
 				$file = "http://publisher.tradedoubler.com".$matches[0];
 				$newfile = realpath ( dirname ( COOKIES_BASE_DIR ) ) . '/pdf/'.$matches[2].'.zip';
@@ -499,7 +499,7 @@ class Oara_Network_Publisher_TradeDoubler extends Oara_Network {
 						$obj = array();
 
 						$paymentLine = $paymentLines->item($i)->nodeValue;
-						$value = preg_replace("/[^0-9\.,]/", "", substr($paymentLine, 10));
+						$value = preg_replace('/[^0-9\.,]/', "", substr($paymentLine, 10));
 
 						$date = self::toDate(substr($paymentLine, 0, 10));
 

--- a/Oara/Network/Publisher/Wehkamp.php
+++ b/Oara/Network/Publisher/Wehkamp.php
@@ -250,7 +250,7 @@ class Oara_Network_Publisher_Wehkamp extends Oara_Network {
 		$exportReport = $this->_client->get($urls);
 		
 		
-		if (preg_match("/publisher\/jsp\/general\/logout\.jsp/", $exportReport[0], $match)) {	
+		if (preg_match('/publisher\/jsp\/general\/logout\.jsp/', $exportReport[0], $match)) {
 			$connection = true;
 		}
 		return $connection;
@@ -365,9 +365,9 @@ class Oara_Network_Publisher_Wehkamp extends Oara_Network {
 	
 	public function checkReportError($content, $request, $try = 0) {
 
-		if (preg_match("/\/report\/published\/aAffiliateEventBreakdownReport/", $content, $matches)) {
+		if (preg_match('/\/report\/published\/aAffiliateEventBreakdownReport/', $content, $matches)) {
 			//report too big, we have to download it and read it
-			if (preg_match("/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/", $content, $matches)) {
+			if (preg_match('/(\/report\/published\/(aAffiliateEventBreakdownReport(.*))\.zip)/', $content, $matches)) {
 
 				$file = "https://affiliates.wehkamp.nl".$matches[0];
 				$newfile = realpath ( dirname ( COOKIES_BASE_DIR ) ) . '/pdf/'.$matches[2].'.zip';


### PR DESCRIPTION
It seems that Amazon select box for switching between various tracking tags isn't called "idbox_store_id", but "idbox_tracking_id". Without this parameter being renamed, the report pulls only data for the current tag, set by the cookie.