### PR TITLE
increase zanox customid size to 150 characters.

### DIFF
--- a/Oara/Network/Publisher/Zanox.php
+++ b/Oara/Network/Publisher/Zanox.php
@@ -169,8 +169,8 @@ class Oara_Network_Publisher_Zanox extends Oara_Network {
 					if (isset($transaction->gpps) && $transaction->gpps != null) {
 						foreach ($transaction->gpps->gpp as $gpp) {
 							if ($gpp->id == "zpar0") {
-								if (strlen($gpp->_) > 100) {
-									$gpp->_ = substr($gpp->_, 0, 100);
+								if (strlen($gpp->_) > 150) {
+									$gpp->_ = substr($gpp->_, 0, 150);
 								}
 								$obj['custom_id'] = $gpp->_;
 							}


### PR DESCRIPTION
As per [zanox documentation](http://wiki.zanox.com/en/en/images/8/8a/GPP_Guide_EN_download.pdf)

> Please note that TPV only supports the GPP 'zpar0'. The maximum length of 'zpar0' for TPV is approx. 150 characters.

Unfortunately we cannot implement it "approximately" -_-