### PR TITLE
HasOffers fixes

### DIFF
--- a/Oara/Network/Publisher/HasOffers.php
+++ b/Oara/Network/Publisher/HasOffers.php
@@ -25,8 +25,8 @@
  * @category Oara_Network_Publisher_HasOffers
  * @copyright Fubra Limited
  * @version Release: 01.00
- *         
- *         
+ *
+ *
  */
 class Oara_Network_Publisher_HasOffers extends Oara_Network {
 	/**
@@ -37,7 +37,7 @@ class Oara_Network_Publisher_HasOffers extends Oara_Network {
 	 * Password
 	 */
 	private $_apiPassword = null;
-	
+
 	/**
 	 * Constructor.
 	 *
@@ -47,17 +47,17 @@ class Oara_Network_Publisher_HasOffers extends Oara_Network {
 	 */
 	public function __construct($credentials) {
 		ini_set ( 'default_socket_timeout', '120' );
-		
+
 		$this->_domain = $credentials["domain"];
 		$this->_apiPassword = $credentials["apiPassword"];
-		
+
 	}
 	/**
 	 * Check the connection
 	 */
 	public function checkConnection() {
 		$connection = false;
-		
+
 		$apiURL = "http://api.hasoffers.com/v3/Affiliate_Offer.json?Method=findMyOffers&api_key={$this->_apiPassword}&NetworkId={$this->_domain}";
 		$response = self::call($apiURL);
 		if (count($response["response"]["errors"]) == 0){
@@ -74,15 +74,15 @@ class Oara_Network_Publisher_HasOffers extends Oara_Network {
 		$merchants = array ();
 		$apiURL = "http://api.hasoffers.com/v3/Affiliate_Offer.json?Method=findMyOffers&api_key={$this->_apiPassword}&NetworkId={$this->_domain}";
 		$response = self::call($apiURL);
-		
+
 		foreach ($response["response"]["data"] as $merchant){
-			
+
 			$obj = Array ();
 			$obj ['cid'] = $merchant["Offer"]["id"];
 			$obj ['name'] = $merchant["Offer"]["name"];
 			$merchants [] = $obj;
 		}
-		
+
 		return $merchants;
 	}
 	/**
@@ -92,33 +92,37 @@ class Oara_Network_Publisher_HasOffers extends Oara_Network {
 	 */
 	public function getTransactionList($merchantList = null, Zend_Date $dStartDate = null, Zend_Date $dEndDate = null, $merchantMap = null) {
 		$totalTransactions = array ();
-		
+
 		//fields[]=Stat.offer_id&fields[]=Stat.datetime&fields[]=Offer.name&fields[]=Stat.conversion_status&fields[]=Stat.payout&fields[]=Stat.conversion_sale_amount&fields[]=Stat.ip&fields[]=Stat.ad_id&fields[]=Stat.affiliate_info1&sort[Stat.datetime]=desc&filters[Stat.date][conditional]=BETWEEN&filters[Stat.date][values][]=2014-03-13&filters[Stat.date][values][]=2014-03-19&data_start=2014-03-13&data_end=2014-03-19
-		
-		
+
+
 		$limit = 100;
 		$page = 1;
 		$loop = true;
 		while ($loop){
-		
-			$apiURL = "http://api.hasoffers.com/v3/Affiliate_Report.json?limit=$limit&page=$page&Method=getConversions&api_key={$this->_apiPassword}&NetworkId={$this->_domain}&fields[]=Stat.offer_id&fields[]=Stat.datetime&fields[]=Offer.name&fields[]=Stat.conversion_status&fields[]=Stat.payout&fields[]=Stat.conversion_sale_amount&fields[]=Stat.ip&fields[]=Stat.ad_id&fields[]=Stat.affiliate_info1&sort[Stat.datetime]=desc&filters[Stat.date][conditional]=BETWEEN&filters[Stat.date][values][]={$dStartDate->toString("yyyy-MM-dd")}&filters[Stat.date][values][]={$dEndDate->toString("yyyy-MM-dd")}&data_start={$dStartDate->toString("yyyy-MM-dd")}&data_end={$dEndDate->toString("yyyy-MM-dd")}";
-			
+
+			$apiURL = "http://api.hasoffers.com/v3/Affiliate_Report.json?limit=$limit&page=$page&Method=getConversions&api_key={$this->_apiPassword}&NetworkId={$this->_domain}&fields[]=Stat.offer_id&fields[]=Stat.affiliate_info1&fields[]=Stat.datetime&fields[]=Offer.name&fields[]=Stat.conversion_status&fields[]=Stat.payout&fields[]=Stat.conversion_sale_amount&fields[]=Stat.ip&fields[]=Stat.ad_id&fields[]=Stat.affiliate_info1&sort[Stat.datetime]=desc&filters[Stat.date][conditional]=BETWEEN&filters[Stat.date][values][]={$dStartDate->toString("yyyy-MM-dd")}&filters[Stat.date][values][]={$dEndDate->toString("yyyy-MM-dd")}&data_start={$dStartDate->toString("yyyy-MM-dd")}&data_end={$dEndDate->toString("yyyy-MM-dd")}";
+
 			$response = self::call($apiURL);
 			foreach ($response["response"]["data"]["data"] as $transactionApi){
-					
+
 				$transaction = Array();
 				$merchantId = (int) $transactionApi["Stat"]["offer_id"];
-				
-				if (in_array($merchantId, $merchantList)){
+
+				if ($merchantList == null || in_array($merchantId, $merchantList)) {
 					$transaction['merchantId'] = $merchantId;
-						
+
 					$transactionDate = new Zend_Date($transactionApi["Stat"]["datetime"], 'yyyy-MM-dd HH:mm:ss', 'en');
 					$transaction['date'] = $transactionDate->toString("yyyy-MM-dd HH:mm:ss");
-						
+
 					if ($transactionApi["Stat"]["ad_id"] != null) {
-						$transaction['custom_id'] = $transactionApi["Stat"]["ad_id"];
+						$transaction['unique_id'] = $transactionApi["Stat"]["ad_id"];
 					}
-						
+
+					if ($transactionApi["Stat"]["affiliate_info1"] != null) {
+						$transaction['custom_id'] = $transactionApi["Stat"]["affiliate_info1"];
+					}
+
 					if ($transactionApi["Stat"]["conversion_status"] == "approved") {
 						$transaction['status'] = Oara_Utilities::STATUS_CONFIRMED;
 					} else
@@ -134,19 +138,19 @@ class Oara_Network_Publisher_HasOffers extends Oara_Network {
 					}
 					$transaction['commission'] = $transactionApi["Stat"]["payout"];
 					$totalTransactions[] = $transaction;
-					
+
 				}
-				
+
 			}
 			if ((int)$response["response"]["data"]["pageCount"] <= $page){
 				$loop = false;
 			}
 			$page++;
-				
+
 		}
 		return $totalTransactions;
 	}
-	
+
 	/**
 	 * (non-PHPdoc)
 	 *
@@ -154,26 +158,26 @@ class Oara_Network_Publisher_HasOffers extends Oara_Network {
 	 */
 	public function getPaymentHistory() {
 		$paymentHistory = array ();
-		
+
 		return $paymentHistory;
 	}
-	
+
 	private function call($apiUrl){
-		
-		
+
+
 		// Initiate the REST call via curl
 		$ch = curl_init($apiUrl);
-			
+
 		// Set the HTTP method to GET
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
 		// Don't return headers
 		curl_setopt($ch, CURLOPT_HEADER, false);
 		// Return data after call is made
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		
+
 		// Execute the REST call
 		$response = curl_exec($ch);
-		
+
 		$array = json_decode($response, true);
 		// Close the connection
 		curl_close($ch);

--- a/Oara/Network/Publisher/HasOffers.php
+++ b/Oara/Network/Publisher/HasOffers.php
@@ -101,7 +101,7 @@ class Oara_Network_Publisher_HasOffers extends Oara_Network {
 		$loop = true;
 		while ($loop){
 
-			$apiURL = "http://api.hasoffers.com/v3/Affiliate_Report.json?limit=$limit&page=$page&Method=getConversions&api_key={$this->_apiPassword}&NetworkId={$this->_domain}&fields[]=Stat.offer_id&fields[]=Stat.affiliate_info1&fields[]=Stat.datetime&fields[]=Offer.name&fields[]=Stat.conversion_status&fields[]=Stat.payout&fields[]=Stat.conversion_sale_amount&fields[]=Stat.ip&fields[]=Stat.ad_id&fields[]=Stat.affiliate_info1&sort[Stat.datetime]=desc&filters[Stat.date][conditional]=BETWEEN&filters[Stat.date][values][]={$dStartDate->toString("yyyy-MM-dd")}&filters[Stat.date][values][]={$dEndDate->toString("yyyy-MM-dd")}&data_start={$dStartDate->toString("yyyy-MM-dd")}&data_end={$dEndDate->toString("yyyy-MM-dd")}";
+			$apiURL = "http://api.hasoffers.com/v3/Affiliate_Report.json?limit=$limit&page=$page&Method=getConversions&api_key={$this->_apiPassword}&NetworkId={$this->_domain}&fields[]=Stat.offer_id&fields[]=Stat.datetime&fields[]=Offer.name&fields[]=Stat.conversion_status&fields[]=Stat.payout&fields[]=Stat.conversion_sale_amount&fields[]=Stat.ip&fields[]=Stat.ad_id&fields[]=Stat.affiliate_info1&sort[Stat.datetime]=desc&filters[Stat.date][conditional]=BETWEEN&filters[Stat.date][values][]={$dStartDate->toString("yyyy-MM-dd")}&filters[Stat.date][values][]={$dEndDate->toString("yyyy-MM-dd")}&data_start={$dStartDate->toString("yyyy-MM-dd")}&data_end={$dEndDate->toString("yyyy-MM-dd")}";
 
 			$response = self::call($apiURL);
 			foreach ($response["response"]["data"]["data"] as $transactionApi){


### PR DESCRIPTION
1. allow to call `getTransactionList` with empty `$merchantList` (means get all merchants like in others Publishers)
1. little fix with `custom_id` and `unique_id` (as far as I understood, `unique_id` is unique transaction ID given from affiliation api/report, and `custom_id` is string/id which Publisher could append to affiliate link by itself (ie. "EPI" value in TradeDoubler or "[Custom Variable](http://help.tune.com/hasoffers/custom-variables/)" in HasOffers/Tune)).

Also as is in README:

```
* unique_id - Unique id for the transaction (string)

* custom_id - Custom id (or sub id) for the transaction (string), custom param you put on your links to see the performance or who made the sale.
```